### PR TITLE
Replace backticks with modern command substitution

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -71,7 +71,7 @@
 	},
 	"cmd": {
 		"prefix": "cmd",
-		"body": "`${1:command}`\n",
+		"body": "$(${1:command})\n",
 		"description": "run command (command substitution)"
 	},
 	"cmd_nice": {


### PR DESCRIPTION
I think every style guide recommends to use $() instead of backticks