### PR TITLE
Fix command success/failure

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -805,7 +805,7 @@ myArray[${2:index}]="value"
 check if last command failed [&uarr;](#Commands)
 
 ```bash
-if [[ $? != 0 ]]; then
+if (( $? != 0 )); then
   echo "Last command failed"
 fi
 ```
@@ -869,7 +869,7 @@ result="$(${2:command})"
 check if last command succeed [&uarr;](#Commands)
 
 ```bash
-if [[ $? == 0 ]]; then
+if (( $? == 0 )); then
   echo "Last command succeed"
 fi
 ```

--- a/nsroot/command/failure-check.json
+++ b/nsroot/command/failure-check.json
@@ -4,7 +4,7 @@
     "cmd failure check"
   ],
   "body": [
-    "if [[ \\$? != 0 ]]; then",
+    "if (( \\$? != 0 )); then",
     "\t${1:echo \"Last command failed\"}",
     "fi\n"
   ],

--- a/nsroot/command/success-check.json
+++ b/nsroot/command/success-check.json
@@ -4,7 +4,7 @@
     "cmd success check"
   ],
   "body": [
-    "if [[ \\$? == 0 ]]; then",
+    "if (( \\$? == 0 )); then",
     "\t${1:echo \"Last command succeed\"}",
     "fi\n"
   ],

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -151,7 +151,7 @@
       "cmd failure check"
     ],
     "body": [
-      "if [[ \\$? != 0 ]]; then",
+      "if (( \\$? != 0 )); then",
       "\t${1:echo \"Last command failed\"}",
       "fi\n"
     ],
@@ -209,7 +209,7 @@
       "cmd success check"
     ],
     "body": [
-      "if [[ \\$? == 0 ]]; then",
+      "if (( \\$? == 0 )); then",
       "\t${1:echo \"Last command succeed\"}",
       "fi\n"
     ],


### PR DESCRIPTION
This closes #30 to provide a safer way to express numerical comparisons